### PR TITLE
Invalid package name

### DIFF
--- a/setuplinuxdesktop-arch.md
+++ b/setuplinuxdesktop-arch.md
@@ -46,7 +46,7 @@
 ## media-production
 - #### obs
   ```bash
-  sudo pacman -S obs
+  sudo pacman -S obs-studio
   ```
 - #### audacity
   ```bash


### PR DESCRIPTION
Changed `obs` to `obs-studio` because `obs` does not exist (but `obs-studio` does)